### PR TITLE
Merge branch 'scenemanagement' into 'link-hierarchy'

### DIFF
--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -6,6 +6,12 @@
 
 #include <assert.h>
 
+GameObject::GameObject(const char* name) : name(name)
+{
+	Component* transform = new ComponentTransform(true, this);
+	components.push_back(transform);
+}
+
 GameObject::GameObject(const char* name, GameObject* parent) : name(name), parent(parent)
 {
 	if(this->parent != nullptr)
@@ -46,13 +52,13 @@ void GameObject::SetParent(GameObject* parent)
 
 void GameObject::AddChild(GameObject* child)
 {
-	if (!IsADescendant(child))
+	if (!IsAChild(child))
 		children.push_back(child);
 }
 
 void GameObject::RemoveChild(GameObject* child)
 {
-	if (IsADescendant(child))
+	if (IsAChild(child))
 	{
 		bool loop = true;
 
@@ -103,15 +109,15 @@ Component* GameObject::CreateComponent(ComponentType type)
 	return newComponent;
 }
 
-bool GameObject::IsADescendant(const GameObject* descendant)
+bool GameObject::IsAChild(const GameObject* child)
 {
-	bool isChild = false;
+	bool isAChild = false;
 
-	for (GameObject* child : children)
+	for (GameObject* gameObject : children)
 	{
-		if (child == descendant || child->IsADescendant(descendant))
-			isChild = true;
+		if (gameObject == child)
+			isAChild = true;
 	}
 
-	return isChild;
+	return isAChild;
 }

--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -59,14 +59,12 @@ void GameObject::RemoveChild(GameObject* child)
 {
 	if (IsAChild(child))
 	{
-		bool loop = true;
-
-		for (std::vector<GameObject*>::const_iterator it = children.begin(); it != children.end() && loop; ++it)
+		for (std::vector<GameObject*>::const_iterator it = children.begin(); it != children.end(); ++it)
 		{
 			if (*it == child)
 			{
 				children.erase(it);
-				loop = false;
+				return;
 			}
 		}
 	}

--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -107,9 +107,9 @@ bool GameObject::IsADescendant(const GameObject* descendant)
 {
 	bool isChild = false;
 
-	for (std::vector<GameObject*>::const_iterator it = children.begin(); it != children.end() && !isChild; ++it)
+	for (GameObject* child : children)
 	{
-		if (*it == descendant || (*it)->IsADescendant(descendant))
+		if (child == descendant || child->IsADescendant(descendant))
 			isChild = true;
 	}
 

--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -42,12 +42,11 @@ void GameObject::Update()
 void GameObject::SetParent(GameObject* parent)
 {
 	if (this->parent != nullptr)
+	{
 		this->parent->RemoveChild(this);
-
-	this->parent = parent;
-
-	if (this->parent != nullptr)
+		this->parent = parent;
 		this->parent->AddChild(this);
+	}	
 }
 
 void GameObject::AddChild(GameObject* child)

--- a/Source/DataModels/GameObject/GameObject.h
+++ b/Source/DataModels/GameObject/GameObject.h
@@ -9,7 +9,8 @@ enum class ComponentType;
 class GameObject
 {
 public:
-	GameObject(const char* name, GameObject* parent = nullptr);
+	explicit GameObject(const char* name);
+	GameObject(const char* name, GameObject* parent);
 	~GameObject();
 
 	void Update();
@@ -29,7 +30,7 @@ public:
 	Component* CreateComponent(ComponentType type);
 
 private:
-	bool IsADescendant(const GameObject* descendant);
+	bool IsAChild(const GameObject* child);
 
 private:
 	bool active = true;

--- a/Source/DataModels/GameObject/GameObject.h
+++ b/Source/DataModels/GameObject/GameObject.h
@@ -9,17 +9,27 @@ enum class ComponentType;
 class GameObject
 {
 public:
-	GameObject(const char* name, GameObject* parent);
+	GameObject(const char* name, GameObject* parent = nullptr);
 	~GameObject();
 
 	void Update();
 
-	const char* GetName() const;
-	Component* CreateComponent(ComponentType type);
+	void SetParent(GameObject* parent);
+	void AddChild(GameObject* child);
+	void RemoveChild(GameObject* child);
 
 	bool GetActive() const;
+	const char* GetName() const;
+	GameObject* GetParent() const;
+	const std::vector<GameObject*>& GetChildren() const;
+
 	void Enable();
 	void Disable();
+
+	Component* CreateComponent(ComponentType type);
+
+private:
+	bool IsADescendant(const GameObject* descendant);
 
 private:
 	bool active = true;
@@ -30,14 +40,24 @@ private:
 	std::vector<GameObject*> children = {};
 };
 
+inline bool GameObject::GetActive() const
+{
+	return active;
+}
+
 inline const char* GameObject::GetName() const
 {
 	return name.c_str();
 }
 
-inline bool GameObject::GetActive() const 
+inline GameObject* GameObject::GetParent() const
 {
-	return active;
+	return parent;
+}
+
+inline const std::vector<GameObject*>& GameObject::GetChildren() const
+{
+	return children;
 }
 
 inline void GameObject::Enable()

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -4,7 +4,17 @@ ModuleScene::ModuleScene()
 {}
 
 ModuleScene::~ModuleScene()
-{}
+{
+	delete root;
+	root = nullptr;
+}
+
+bool ModuleScene::Init()
+{
+	root = new GameObject("Root");
+
+	return true;
+}
 
 update_status ModuleScene::Update()
 {

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -1,6 +1,29 @@
 #include "ModuleScene.h"
 
-GameObject* ModuleScene::CreateGameObject()
+ModuleScene::ModuleScene()
+{}
+
+ModuleScene::~ModuleScene()
+{}
+
+update_status ModuleScene::Update()
 {
-    return nullptr;
+	UpdateGameObjectAndDescendants(root);
+
+	return UPDATE_CONTINUE;
+}
+
+GameObject* ModuleScene::CreateGameObject(const char* name, GameObject* parent)
+{
+	GameObject* gameObject = new GameObject(name, parent);
+
+	return gameObject;
+}
+
+void ModuleScene::UpdateGameObjectAndDescendants(GameObject* gameObject)
+{
+	gameObject->Update();
+
+	for (GameObject* child : gameObject->GetChildren())
+		UpdateGameObjectAndDescendants(child);
 }

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -1,4 +1,5 @@
 #include "ModuleScene.h"
+#include "GameObject/GameObject.h"
 
 ModuleScene::ModuleScene()
 {}

--- a/Source/Modules/ModuleScene.h
+++ b/Source/Modules/ModuleScene.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "Module.h"
-#include "GameObject/GameObject.h"
+
+class GameObject;
 
 class ModuleScene :public Module
 {

--- a/Source/Modules/ModuleScene.h
+++ b/Source/Modules/ModuleScene.h
@@ -1,15 +1,22 @@
 #pragma once
 
 #include "Module.h"
-
-class GameObject;
+#include "GameObject/GameObject.h"
 
 class ModuleScene :public Module
 {
 public:
-	GameObject* CreateGameObject();
+	ModuleScene();
+	~ModuleScene();
+
+	update_status Update() override;
+
+	GameObject* CreateGameObject(const char* name, GameObject* parent);
 
 private:
-	GameObject* root;
+	void UpdateGameObjectAndDescendants(GameObject* gameObject);
+
+private:
+	GameObject* root = nullptr;
 };
 

--- a/Source/Modules/ModuleScene.h
+++ b/Source/Modules/ModuleScene.h
@@ -9,6 +9,7 @@ public:
 	ModuleScene();
 	~ModuleScene();
 
+	bool Init() override;
 	update_status Update() override;
 
 	GameObject* CreateGameObject(const char* name, GameObject* parent);


### PR DESCRIPTION
Finally, the GameObject Constructor has been implemented in this way ("GameObject(const char* name, GameObject* parent = nullptr)") to be able to encapsulate two ways of calling it.

In case of needing a root GameObject this is the correct way to call the constructor: GameObject("root-name").

Otherwise, it will be called like this: GameObject("node-name", parent).
